### PR TITLE
chore(release): prepare 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.3.0] (2026-08-30)
+
 - Distribute platform-specific packages, adding Linux arm64, Alpine x64, and macOS arm64 support while retaining Linux x64 and macOS x64.
 - Update the bundled command-help parser to the pinned and verified v0.6.0 release.
 - Use a POSIX `sh` wrapper so the bundled command-help parser works in minimal Linux environments such as Alpine.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-h2o",
-    "version": "0.2.15",
+    "version": "0.3.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-h2o",
-            "version": "0.2.15",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
                 "node-fetch": "^2.6.6",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-h2o",
     "displayName": "Shell Script Command Completion",
-    "version": "0.2.15",
+    "version": "0.3.0",
     "description": "Complete shell commands and view inline help in shell scripts and BitBake files",
     "repository": {
         "url": "https://github.com/yamaton/vscode-h2o"


### PR DESCRIPTION
## Summary

- bump the extension version to 0.3.0
- finalize the 0.3.0 changelog entry

## Verification

- npm run check:unit (lint, typecheck, build, and 151 coverage tests passed; the release-tools phase was rerun outside the filesystem sandbox because its local HTTP fixture could not listen there)
- npm run test:release-tools