### PR TITLE
Release 0.3.1 with scannerless Windows packages

### DIFF
--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -25,7 +25,7 @@ publish job to Microsoft Entra ID authentication before that date.
 3. Merge the version bump after the quality gate passes.
 
 The publish workflow verifies that the manifest and lockfile versions agree and increased from the previous `main`
-commit. It then re-runs the complete quality workflow, downloads its five verified platform-specific VSIX artifacts,
+commit. It then re-runs the complete quality workflow, downloads its seven verified platform-specific VSIX artifacts,
 verifies them again, and waits for approval on the `marketplace` environment. After approval it verifies Marketplace
 publishing rights, creates the immutable unprefixed version tag at the merged commit, publishes all targets together,
 and confirms the new Marketplace version.

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -94,6 +94,10 @@ jobs:
             runner: macos-15-intel
           - target: linux-arm64
             runner: ubuntu-24.04-arm
+          - target: win32-arm64
+            runner: ubuntu-24.04
+          - target: win32-x64
+            runner: ubuntu-24.04
     steps:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -122,6 +126,40 @@ jobs:
           if-no-files-found: error
           compression-level: 0
           retention-days: 7
+
+  integration-windows:
+    name: Packaged Extension Host (stable / Windows x64, scannerless)
+    needs: package-platforms
+    runs-on: windows-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install locked dependencies
+        run: npm ci
+
+      - name: Build packaged smoke test
+        run: npm run build
+
+      - name: Download verified Windows x64 VSIX
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: vscode-h2o-win32-x64-${{ github.sha }}
+          path: artifacts
+
+      - name: Activate scannerless Windows VSIX
+        run: node ./out/test/runVsixTest.js artifacts/vscode-h2o-win32-x64.vsix
+        env:
+          VSCODE_H2O_EXPECT_SCANNERLESS_WINDOWS: '1'
 
   integration-linux:
     name: Extension Host (${{ matrix.label }})

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -335,6 +335,7 @@ jobs:
     needs:
       - unit-and-package
       - package-platforms
+      - integration-windows
       - integration-linux
       - integration-macos-intel
       - performance-shadow
@@ -345,11 +346,12 @@ jobs:
         env:
           UNIT_AND_PACKAGE: ${{ needs.unit-and-package.result }}
           PACKAGE_PLATFORMS: ${{ needs.package-platforms.result }}
+          INTEGRATION_WINDOWS: ${{ needs.integration-windows.result }}
           INTEGRATION_LINUX: ${{ needs.integration-linux.result }}
           INTEGRATION_MACOS_INTEL: ${{ needs.integration-macos-intel.result }}
           PERFORMANCE_SHADOW: ${{ needs.performance-shadow.result }}
         run: |
-          for result in "${UNIT_AND_PACKAGE}" "${PACKAGE_PLATFORMS}" "${INTEGRATION_LINUX}" "${INTEGRATION_MACOS_INTEL}"; do
+          for result in "${UNIT_AND_PACKAGE}" "${PACKAGE_PLATFORMS}" "${INTEGRATION_WINDOWS}" "${INTEGRATION_LINUX}" "${INTEGRATION_MACOS_INTEL}"; do
             if [[ "${result}" != success ]]; then
               echo "A required quality job concluded with: ${result}" >&2
               exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## [0.3.1] (2026-08-30)
+
+- Publish Windows x64 and arm64 packages without H2O or local `--help` scanning. Downloaded and cached completion and hover data remain available, and Windows users are not prompted to enable local scans.
+
 ## [0.3.0] (2026-08-30)
 
 - Distribute platform-specific packages, adding Linux arm64, Alpine x64, and macOS arm64 support while retaining Linux x64 and macOS x64.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The common collection currently contains more than 400 command specifications, i
 
 When an installed command is not in the cache, the extension can create a specification from its `--help` output and save it for later use. The bundled command-help parser does not consult man pages.
 
-Local help scans are disabled by default. When the extension activates on an Extension Host with neither an explicit setting nor a recorded response, it asks whether it may run commands referenced by Shell Script or BitBake files with `--help` there. Choosing **Allow Local Scans** sets `shellCompletion.scanUnknownCommands` to `true`; choosing **Keep Disabled** or dismissing the notification leaves downloaded and previously cached specifications available without executing uncached commands.
+Local help scans are disabled by default. On Linux, WSL, and macOS, when the extension activates on an Extension Host with neither an explicit setting nor a recorded response, it asks whether it may run commands referenced by Shell Script or BitBake files with `--help` there. Choosing **Allow Local Scans** sets `shellCompletion.scanUnknownCommands` to `true`; choosing **Keep Disabled** or dismissing the notification leaves downloaded and previously cached specifications available without executing uncached commands. Windows packages do not include the scanner and do not offer this choice.
 
 You can change `shellCompletion.scanUnknownCommands` later in user settings, or in remote settings when using a remote Extension Host. The machine-scoped setting is not synchronized, and a workspace cannot override it.
 
@@ -86,7 +86,7 @@ For a compact view that follows caret movement, document edits, and hover reques
 
 While live inspection is enabled, a single status bar item shows only the high-level state, for example `H2O C✓ H— TS:word`. `C` is completion, `H` is hover, and `TS` is the tree-sitter node at the caret. Click it to reveal the debug views. The view toolbar can pause and resume updates. Each view also has an **Open Debug Snapshot** action that opens its full current data as a read-only virtual JSON document for searching and copying; live JSON is no longer streamed through an Output channel. Run **Shell Completion: Toggle Live Caret and Cursor Context** to disable or re-enable the interface.
 
-The executable that parses local command `--help` output can also be selected with the `shellCompletion.h2oPath` setting. Its default value, `<bundled>`, uses the parser packaged for the current platform. Like the unknown-command scan policy, this is a machine setting and is configured separately for a remote Extension Host.
+The executable that parses local command `--help` output can also be selected with the `shellCompletion.h2oPath` setting. On supported Extension Hosts, its default value, `<bundled>`, uses the parser packaged for the current platform. Windows packages do not include this parser. Like the unknown-command scan policy, this is a machine setting and is configured separately for a remote Extension Host.
 
 Completion suggestions can be enabled or disabled independently with `shellCompletion.enableCompletion`. This window-scoped setting can be configured in user, workspace, or remote settings; disabling it does not disable hover or remove cached specifications.
 
@@ -102,7 +102,7 @@ Completion and hover based on downloaded or previously cached command specificat
 | Linux on glibc-based distributions | arm64 | Supported |
 | macOS | x64, arm64 | Supported |
 | Alpine | arm64 | Not currently supported |
-| Windows | x64, arm64 | Not supported; use downloaded or cached specifications |
+| Windows | x64, arm64 | Not supported; the Windows packages omit the scanner and use downloaded or cached specifications |
 
 Remote environments such as WSL use the platform of their VS Code Extension Host to determine unknown-command scanning support. VS Code 1.101 or later is required.
 
@@ -149,5 +149,5 @@ To adjust suggestions from every provider instead, use VS Code's **Quick Suggest
 ## Known Limitations
 
 * BitBake support is experimental and requires another extension that provides the `bitbake` language mode.
-* Windows and Alpine arm64 Extension Hosts are not currently supported by the bundled scanner.
+* Windows packages do not include the scanner, and Alpine arm64 Extension Hosts are not currently supported by it.
 * Completion and hover information depend on either a cached curated specification or, when unknown-command scanning is enabled, successful extraction from the local command's `--help` output.

--- a/h2o.lock.json
+++ b/h2o.lock.json
@@ -8,7 +8,9 @@
     "darwin-arm64": "aarch64-apple-darwin",
     "darwin-x64": "x86_64-apple-darwin",
     "linux-arm64": "aarch64-unknown-linux-gnu",
-    "linux-x64": "x86_64-unknown-linux-musl"
+    "linux-x64": "x86_64-unknown-linux-musl",
+    "win32-arm64": null,
+    "win32-x64": null
   },
   "assets": {
     "aarch64-apple-darwin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-h2o",
-    "version": "0.3.0",
+    "version": "0.3.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-h2o",
-            "version": "0.3.0",
+            "version": "0.3.1",
             "license": "MIT",
             "dependencies": {
                 "node-fetch": "^2.6.6",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-h2o",
     "displayName": "Shell Script Command Completion",
-    "version": "0.3.0",
+    "version": "0.3.1",
     "description": "Complete shell commands and view inline help in shell scripts and BitBake files",
     "repository": {
         "url": "https://github.com/yamaton/vscode-h2o"
@@ -195,7 +195,7 @@
                     "type": "string",
                     "default": "<bundled>",
                     "scope": "machine",
-                    "markdownDescription": "Path on the Extension Host to the executable that parses local command `--help` output into command specifications. Use `<bundled>` for the parser packaged with the extension."
+                    "markdownDescription": "Path on a Linux, WSL, or macOS Extension Host to the executable that parses local command `--help` output into command specifications. Use `<bundled>` for the parser packaged with the extension. Local command scanning is unavailable on Windows."
                 },
                 "shellCompletion.maxDocumentCharacters": {
                     "type": "integer",
@@ -214,7 +214,7 @@
                     "type": "boolean",
                     "default": false,
                     "scope": "machine",
-                    "markdownDescription": "Whether commands missing from the command-specification cache may be executed with `--help` to generate specifications. Local scans are disabled by default; the extension offers this choice on activation when no explicit setting or prior response exists. Downloaded and cached specifications remain available when disabled."
+                    "markdownDescription": "Whether commands missing from the command-specification cache may be executed with `--help` to generate specifications on Linux, WSL, or macOS. Local scans are unavailable on Windows. They are disabled by default on supported hosts; the extension offers this choice on activation when no explicit setting or prior response exists. Downloaded and cached specifications remain available when disabled."
                 }
             }
         },

--- a/scripts/lib/h2o-release.mjs
+++ b/scripts/lib/h2o-release.mjs
@@ -77,6 +77,10 @@ export function validateH2oLock(lock) {
 
   for (const [vsixTarget, h2oTarget] of Object.entries(lock.vsixTargets)) {
     assertSafeName(vsixTarget, 'VSIX target');
+    if (h2oTarget === null) {
+      assert.ok(vsixTarget.startsWith('win32-'), `only Windows VSIX targets may omit H2O: ${vsixTarget}`);
+      continue;
+    }
     assert.ok(lock.assets[h2oTarget], `VSIX target ${vsixTarget} refers to an unknown H2O target: ${h2oTarget}`);
     if (vsixTarget.startsWith('alpine-')) {
       assert.strictEqual(lock.assets[h2oTarget].static, true, `${vsixTarget} requires a static H2O asset`);
@@ -85,8 +89,14 @@ export function validateH2oLock(lock) {
 }
 
 export function h2oTargetForVsix(lock, vsixTarget) {
+  assert.ok(Object.hasOwn(lock.vsixTargets, vsixTarget), `unsupported VSIX target: ${vsixTarget}`);
   const h2oTarget = lock.vsixTargets[vsixTarget];
-  assert.ok(h2oTarget, `unsupported VSIX target: ${vsixTarget}`);
+  return h2oTarget;
+}
+
+export function requireH2oTargetForVsix(lock, vsixTarget) {
+  const h2oTarget = h2oTargetForVsix(lock, vsixTarget);
+  assert.ok(h2oTarget, `${vsixTarget} does not bundle H2O`);
   return h2oTarget;
 }
 

--- a/scripts/lib/vsix-file-contract.mjs
+++ b/scripts/lib/vsix-file-contract.mjs
@@ -35,6 +35,18 @@ export const requiredExtensionFiles = [
   'extension/tree-sitter-bash.wasm',
 ];
 
+const bundledScannerFiles = new Set([
+  'extension/bin/h2o',
+  'extension/bin/profile.sb',
+  'extension/bin/wrap-h2o',
+]);
+
+export function requiredExtensionFilesForVsix(bundledScanner) {
+  return bundledScanner
+    ? requiredExtensionFiles
+    : requiredExtensionFiles.filter(file => !bundledScannerFiles.has(file));
+}
+
 const generatedExtensionFiles = [
   '[Content_Types].xml',
   'extension.vsixmanifest',

--- a/scripts/package-platform.mjs
+++ b/scripts/package-platform.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
-import { mkdirSync, renameSync, rmSync } from 'node:fs';
+import { mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 import { h2oTargetForVsix, loadH2oLock } from './lib/h2o-release.mjs';
@@ -22,17 +22,27 @@ const vsixTarget = parseArguments(process.argv.slice(2));
 const h2oTarget = h2oTargetForVsix(lock, vsixTarget);
 const output = path.join(projectRoot, 'artifacts', `vscode-h2o-${vsixTarget}.vsix`);
 const temporaryOutput = path.join(projectRoot, 'artifacts', `.vscode-h2o-${vsixTarget}.${process.pid}.tmp.vsix`);
+const temporaryIgnore = path.join(projectRoot, 'artifacts', `.vscodeignore-${vsixTarget}.${process.pid}`);
+const bundledScanner = h2oTarget !== null;
 
 mkdirSync(path.dirname(output), { recursive: true });
 rmSync(temporaryOutput, { force: true });
 
 try {
-  run(process.execPath, [path.join(projectRoot, 'scripts/fetch-h2o.mjs'), '--target', h2oTarget]);
-  run(process.execPath, [path.join(projectRoot, 'scripts/stage-h2o-bundle.mjs'), vsixTarget]);
-  run(process.execPath, [path.join(projectRoot, 'scripts/verify-native.mjs'), vsixTarget]);
-  run('npx', ['--no-install', 'vsce', 'package', '--target', vsixTarget, '--out', temporaryOutput]);
+  const packageArguments = ['--no-install', 'vsce', 'package', '--target', vsixTarget, '--out', temporaryOutput];
+  if (bundledScanner) {
+    run(process.execPath, [path.join(projectRoot, 'scripts/fetch-h2o.mjs'), '--target', h2oTarget]);
+    run(process.execPath, [path.join(projectRoot, 'scripts/stage-h2o-bundle.mjs'), vsixTarget]);
+    run(process.execPath, [path.join(projectRoot, 'scripts/verify-native.mjs'), vsixTarget]);
+  } else {
+    const baseIgnore = readFileSync(path.join(projectRoot, '.vscodeignore'), 'utf8');
+    writeFileSync(temporaryIgnore, `${baseIgnore}\nbin/h2o\nbin/profile.sb\nbin/wrap-h2o\n`);
+    packageArguments.push('--ignoreFile', temporaryIgnore);
+  }
+  run('npx', packageArguments);
   run(process.execPath, [path.join(projectRoot, 'scripts/verify-vsix.mjs'), temporaryOutput, vsixTarget]);
   renameSync(temporaryOutput, output);
 } finally {
   rmSync(temporaryOutput, { force: true });
+  rmSync(temporaryIgnore, { force: true });
 }

--- a/scripts/stage-h2o-bundle.mjs
+++ b/scripts/stage-h2o-bundle.mjs
@@ -1,12 +1,12 @@
 import { chmodSync, copyFileSync, mkdirSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
-import { h2oTargetForVsix, loadH2oLock, verifyBinary } from './lib/h2o-release.mjs';
+import { loadH2oLock, requireH2oTargetForVsix, verifyBinary } from './lib/h2o-release.mjs';
 
 const projectRoot = fileURLToPath(new URL('..', import.meta.url));
 const lock = loadH2oLock(path.join(projectRoot, 'h2o.lock.json'));
 const [vsixTarget] = process.argv.slice(2);
-const h2oTarget = h2oTargetForVsix(lock, vsixTarget);
+const h2oTarget = requireH2oTargetForVsix(lock, vsixTarget);
 const asset = lock.assets[h2oTarget];
 
 const source = path.join(projectRoot, 'artifacts', 'h2o', h2oTarget, 'h2o');

--- a/scripts/test-h2o-release.mjs
+++ b/scripts/test-h2o-release.mjs
@@ -6,6 +6,7 @@ import path from 'node:path';
 import {
   loadH2oLock,
   h2oTargetForVsix,
+  requireH2oTargetForVsix,
   validateH2oLock,
   validateArchiveEntries,
   verifyBinaryHeader,
@@ -36,7 +37,10 @@ const statement = {
 verifyReleaseStatement(lock, statement);
 assert.strictEqual(h2oTargetForVsix(lock, 'linux-x64'), 'x86_64-unknown-linux-musl');
 assert.strictEqual(h2oTargetForVsix(lock, 'alpine-x64'), 'x86_64-unknown-linux-musl');
+assert.strictEqual(h2oTargetForVsix(lock, 'win32-x64'), null);
 assert.throws(() => h2oTargetForVsix(lock, 'alpine-arm64'), /unsupported VSIX target/);
+assert.strictEqual(requireH2oTargetForVsix(lock, 'linux-x64'), 'x86_64-unknown-linux-musl');
+assert.throws(() => requireH2oTargetForVsix(lock, 'win32-x64'), /does not bundle H2O/);
 
 const clonedLock = () => JSON.parse(JSON.stringify(lock));
 const wrongTag = clonedLock();
@@ -60,6 +64,10 @@ assert.throws(() => validateH2oLock(unsafeTarget), /invalid H2O target/);
 const unknownVsixAsset = clonedLock();
 unknownVsixAsset.vsixTargets['linux-riscv64'] = 'riscv64-unknown-linux-gnu';
 assert.throws(() => validateH2oLock(unknownVsixAsset), /unknown H2O target/);
+
+const scannerlessLinux = clonedLock();
+scannerlessLinux.vsixTargets['linux-riscv64'] = null;
+assert.throws(() => validateH2oLock(scannerlessLinux), /only Windows VSIX targets may omit H2O/);
 
 const dynamicAlpine = clonedLock();
 delete dynamicAlpine.assets[dynamicAlpine.vsixTargets['alpine-x64']].static;

--- a/scripts/test-vsix-file-contract.mjs
+++ b/scripts/test-vsix-file-contract.mjs
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import {
   compareExtensionFileContract,
   packagedExtensionFiles,
+  requiredExtensionFilesForVsix,
   sourceFileToExtensionPath,
 } from './lib/vsix-file-contract.mjs';
 
@@ -20,6 +21,9 @@ assert.deepStrictEqual(
     'extension/readme.md',
   ],
 );
+
+assert.ok(requiredExtensionFilesForVsix(true).includes('extension/bin/h2o'));
+assert.ok(!requiredExtensionFilesForVsix(false).some(file => file.startsWith('extension/bin/')));
 
 const contractFiles = [
   'extension/out/extension.js',

--- a/scripts/verify-native.mjs
+++ b/scripts/verify-native.mjs
@@ -4,7 +4,7 @@ import { chmodSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync }
 import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
-import { h2oTargetForVsix, loadH2oLock, verifyBinary } from './lib/h2o-release.mjs';
+import { loadH2oLock, requireH2oTargetForVsix, verifyBinary } from './lib/h2o-release.mjs';
 import {
   loadGrammarLock,
   verifyGrammarArtifact,
@@ -16,7 +16,7 @@ const lock = loadH2oLock(path.join(projectRoot, 'h2o.lock.json'));
 const grammarLock = loadGrammarLock(path.join(projectRoot, 'tree-sitter-bash.lock.json'));
 const hostTarget = `${process.platform}-${process.arch}`;
 const vsixTarget = process.argv[2] ?? hostTarget;
-const h2oTarget = h2oTargetForVsix(lock, vsixTarget);
+const h2oTarget = requireH2oTargetForVsix(lock, vsixTarget);
 const binaryPath = 'bin/h2o';
 const executable = path.join(projectRoot, binaryPath);
 verifyBinary(executable, h2oTarget, lock.assets[h2oTarget]);

--- a/scripts/verify-vsix.mjs
+++ b/scripts/verify-vsix.mjs
@@ -10,7 +10,7 @@ import {
   verifyGrammarArtifact,
   verifyGrammarRuntimeCompatibility,
 } from './lib/tree-sitter-grammar.mjs';
-import { requiredExtensionFiles } from './lib/vsix-file-contract.mjs';
+import { requiredExtensionFilesForVsix } from './lib/vsix-file-contract.mjs';
 
 const projectRoot = fileURLToPath(new URL('..', import.meta.url));
 const h2oLock = loadH2oLock(path.join(projectRoot, 'h2o.lock.json'));
@@ -19,6 +19,7 @@ const packageLock = JSON.parse(readFileSync(path.join(projectRoot, 'package-lock
 const vsixPath = path.resolve(projectRoot, process.argv[2] || 'artifacts/vscode-h2o-linux-x64.vsix');
 const vsixTarget = process.argv[3] || 'linux-x64';
 const h2oTarget = h2oTargetForVsix(h2oLock, vsixTarget);
+const bundledScanner = h2oTarget !== null;
 const maxVsixBytes = 12 * 1024 * 1024;
 
 const productionPackages = Object.entries(packageLock.packages)
@@ -50,7 +51,7 @@ const dependencyEntries = entries.filter(entry => entry.startsWith('extension/no
 const extensionEntries = entries.filter(entry => !entry.startsWith('extension/node_modules/'));
 assert.deepStrictEqual(
   [...extensionEntries].sort(),
-  [...requiredExtensionFiles].sort(),
+  [...requiredExtensionFilesForVsix(bundledScanner)].sort(),
   'VSIX contains missing or unexpected extension files',
 );
 
@@ -90,13 +91,15 @@ assert.ok(vsixManifest.includes(`Publisher="${sourceManifest.publisher}"`), 'VSI
 assert.ok(vsixManifest.includes(`Version="${sourceManifest.version}"`), 'VSIX manifest has the wrong version');
 assert.ok(vsixManifest.includes(`TargetPlatform="${vsixTarget}"`), 'VSIX manifest has the wrong target platform');
 
-const packagedH2o = archivedFile('extension/bin/h2o');
-const expectedH2o = h2oLock.assets[h2oTarget];
-assert.strictEqual(packagedH2o.length, expectedH2o.binarySize, 'bin/h2o has an unexpected size');
-assert.strictEqual(sha256(packagedH2o), expectedH2o.binarySha256, 'bin/h2o differs from h2o.lock.json');
-verifyBinaryHeader(packagedH2o, h2oTarget);
-if (expectedH2o.static) {
-  verifyStaticElf(packagedH2o, h2oTarget);
+if (bundledScanner) {
+  const packagedH2o = archivedFile('extension/bin/h2o');
+  const expectedH2o = h2oLock.assets[h2oTarget];
+  assert.strictEqual(packagedH2o.length, expectedH2o.binarySize, 'bin/h2o has an unexpected size');
+  assert.strictEqual(sha256(packagedH2o), expectedH2o.binarySha256, 'bin/h2o differs from h2o.lock.json');
+  verifyBinaryHeader(packagedH2o, h2oTarget);
+  if (expectedH2o.static) {
+    verifyStaticElf(packagedH2o, h2oTarget);
+  }
 }
 
 const packagedWasm = archivedFile(`extension/${grammarLock.file}`);
@@ -104,12 +107,14 @@ verifyGrammarArtifact(packagedWasm, grammarLock, `extension/${grammarLock.file}`
 await verifyGrammarRuntimeCompatibility(packagedWasm, grammarLock, `extension/${grammarLock.file}`);
 
 const zipListing = execFileSync('zipinfo', ['-l', vsixPath], { encoding: 'utf8' });
-for (const file of [
-  'extension/bin/h2o',
-  'extension/bin/wrap-h2o',
-]) {
-  const listingLine = zipListing.split(/\r?\n/).find((line) => line.endsWith(file));
-  assert.ok(listingLine?.startsWith('-rwx'), `${file} lost its executable mode in the VSIX`);
+if (bundledScanner) {
+  for (const file of [
+    'extension/bin/h2o',
+    'extension/bin/wrap-h2o',
+  ]) {
+    const listingLine = zipListing.split(/\r?\n/).find((line) => line.endsWith(file));
+    assert.ok(listingLine?.startsWith('-rwx'), `${file} lost its executable mode in the VSIX`);
+  }
 }
 
 console.log(`VSIX contract checks passed for ${entries.length} files (${statSync(vsixPath).size} bytes).`);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -66,6 +66,7 @@ import {
   requestUnknownCommandScanConsent,
   unknownCommandScanConsentStateKey,
 } from './scanConsent';
+import { supportsLocalCommandScanning } from './h2oRunner';
 
 export type { ProviderSuppressionReason } from './providerContext';
 
@@ -406,7 +407,7 @@ async function registerExtension(
     const enabled = vscode.workspace
       .getConfiguration('shellCompletion')
       .get<boolean>('scanUnknownCommands', false);
-    fetcher.setScanUnknownCommands(enabled);
+    fetcher.setScanUnknownCommands(supportsLocalCommandScanning() && enabled);
   };
   updateUnknownCommandScanPolicy();
   activationRegistrations.push(fetcher);
@@ -1435,38 +1436,40 @@ async function registerExtension(
 
   activationRegistrations.push(vscode.workspace.onDidChangeTextDocument(edit));
   activationRegistrations.push(vscode.workspace.onDidCloseTextDocument(close));
-  void requestUnknownCommandScanConsent({
-    configuredValue: () => vscode.workspace
-      .getConfiguration('shellCompletion')
-      .inspect<boolean>('scanUnknownCommands')?.globalValue,
-    promptedVersion: () => context.globalState.get<number>(unknownCommandScanConsentStateKey),
-    recordPromptedVersion: version => context.globalState.update(
-      unknownCommandScanConsentStateKey,
-      version,
-    ),
-    prompt: async () => {
-      const choice = await vscode.window.showWarningMessage(
-        'Allow Shell Completion to run unknown commands with --help to provide completions?',
-        enableLocalScansLabel,
-        keepLocalScansDisabledLabel,
+  if (supportsLocalCommandScanning()) {
+    void requestUnknownCommandScanConsent({
+      configuredValue: () => vscode.workspace
+        .getConfiguration('shellCompletion')
+        .inspect<boolean>('scanUnknownCommands')?.globalValue,
+      promptedVersion: () => context.globalState.get<number>(unknownCommandScanConsentStateKey),
+      recordPromptedVersion: version => context.globalState.update(
+        unknownCommandScanConsentStateKey,
+        version,
+      ),
+      prompt: async () => {
+        const choice = await vscode.window.showWarningMessage(
+          'Allow Shell Completion to run unknown commands with --help to provide completions?',
+          enableLocalScansLabel,
+          keepLocalScansDisabledLabel,
+        );
+        if (choice === enableLocalScansLabel) {
+          return 'enable';
+        }
+        if (choice === keepLocalScansDisabledLabel) {
+          return 'keep-disabled';
+        }
+        return undefined;
+      },
+      updateConfiguredValue: enabled => vscode.workspace
+        .getConfiguration('shellCompletion')
+        .update('scanUnknownCommands', enabled, vscode.ConfigurationTarget.Global),
+    }).catch(error => {
+      console.error('[Unknown command scans] Failed to handle the local scan choice:', error);
+      void vscode.window.showErrorMessage(
+        'Shell Completion could not finish local command scan setup. Check shellCompletion.scanUnknownCommands in Settings and try again.',
       );
-      if (choice === enableLocalScansLabel) {
-        return 'enable';
-      }
-      if (choice === keepLocalScansDisabledLabel) {
-        return 'keep-disabled';
-      }
-      return undefined;
-    },
-    updateConfiguredValue: enabled => vscode.workspace
-      .getConfiguration('shellCompletion')
-      .update('scanUnknownCommands', enabled, vscode.ConfigurationTarget.Global),
-  }).catch(error => {
-    console.error('[Unknown command scans] Failed to handle the local scan choice:', error);
-    void vscode.window.showErrorMessage(
-      'Shell Completion could not finish local command scan setup. Check shellCompletion.scanUnknownCommands in Settings and try again.',
-    );
-  });
+    });
+  }
   context.subscriptions.push(
     ...activationRegistrations,
     { dispose: () => disposeParserResources(parser, trees) },

--- a/src/h2oRunner.ts
+++ b/src/h2oRunner.ts
@@ -241,7 +241,6 @@ export interface H2oRuntime {
   extensionDir: string;
   platform: NodeJS.Platform;
   getConfiguredPath(): string;
-  showErrorMessage(message: string): void;
   execute(
     command: string,
     args: readonly string[],
@@ -249,7 +248,9 @@ export interface H2oRuntime {
   ): Promise<ProcessOutput>;
 }
 
-let neverNotifiedError = true;
+export function supportsLocalCommandScanning(platform: NodeJS.Platform = process.platform): boolean {
+  return platform === 'linux' || platform === 'darwin';
+}
 
 function createDefaultH2oRuntime(): H2oRuntime {
   // `vscode` is only available inside the extension host. Loading it lazily
@@ -259,9 +260,6 @@ function createDefaultH2oRuntime(): H2oRuntime {
     extensionDir: __dirname,
     platform: process.platform,
     getConfiguredPath: () => vscode.workspace.getConfiguration('shellCompletion').get('h2oPath') as string,
-    showErrorMessage: message => {
-      void vscode.window.showErrorMessage(message);
-    },
     execute: (command, args, options) => executeProcess(command, args, options),
   };
 }
@@ -271,16 +269,12 @@ export async function runH2o(
   runtime: H2oRuntime = createDefaultH2oRuntime(),
   signal?: AbortSignal,
 ): Promise<Command | undefined> {
+  if (!supportsLocalCommandScanning(runtime.platform)) {
+    return undefined;
+  }
+
   let h2opath = runtime.getConfiguredPath();
   if (h2opath === '<bundled>') {
-    if (runtime.platform !== 'linux' && runtime.platform !== 'darwin') {
-      if (neverNotifiedError) {
-        const message = 'Bundled help scanner (H2O) supports Linux and MacOS. Please set the H2O path.';
-        runtime.showErrorMessage(message);
-      }
-      neverNotifiedError = false;
-      return undefined;
-    }
     h2opath = path.join(runtime.extensionDir, '../bin/h2o');
   }
 

--- a/src/test/packaged/index.ts
+++ b/src/test/packaged/index.ts
@@ -27,6 +27,10 @@ async function withTimeout<T>(operation: PromiseLike<T>, timeoutMs: number): Pro
 }
 
 export async function run(): Promise<void> {
+	const expectScannerlessWindows = process.env.VSCODE_H2O_EXPECT_SCANNERLESS_WINDOWS === '1';
+	if (expectScannerlessWindows) {
+		assert.strictEqual(process.platform, 'win32', 'the scannerless Windows smoke must run on Windows');
+	}
 	const extension = vscode.extensions.getExtension(extensionId);
 	assert.ok(extension, `${extensionId} must be installed from the VSIX`);
 	const completionConfiguration = vscode.workspace.getConfiguration('shellCompletion');
@@ -37,7 +41,7 @@ export async function run(): Promise<void> {
 	);
 	await completionConfiguration.update(
 		'scanUnknownCommands',
-		false,
+		expectScannerlessWindows ? undefined : false,
 		vscode.ConfigurationTarget.Global,
 	);
 
@@ -49,6 +53,26 @@ export async function run(): Promise<void> {
 
 	const packagedCacheFetcherModule = require(path.join(extensionPath, 'out/cacheFetcher.js')) as typeof import('../../cacheFetcher');
 	const packagedCachingFetcher = packagedCacheFetcherModule.CachingFetcher;
+	const packagedH2oRunnerModule = require(path.join(extensionPath, 'out/h2oRunner.js')) as {
+		runH2o: typeof import('../../h2oRunner').runH2o;
+	};
+	const originalRunH2o = packagedH2oRunnerModule.runH2o;
+	const packagedScanConsentModule = require(path.join(extensionPath, 'out/scanConsent.js')) as {
+		requestUnknownCommandScanConsent: typeof import('../../scanConsent').requestUnknownCommandScanConsent;
+	};
+	const originalRequestUnknownCommandScanConsent = packagedScanConsentModule.requestUnknownCommandScanConsent;
+	let scanConsentRequests = 0;
+	let localScanCalls = 0;
+	if (expectScannerlessWindows) {
+		packagedH2oRunnerModule.runH2o = async () => {
+			localScanCalls += 1;
+			return undefined;
+		};
+		packagedScanConsentModule.requestUnknownCommandScanConsent = async () => {
+			scanConsentRequests += 1;
+			return 'already-prompted';
+		};
+	}
 	const originalStartInitialCuratedFetch = packagedCachingFetcher.prototype.startInitialCuratedFetch;
 	packagedCachingFetcher.prototype.startInitialCuratedFetch = async () => undefined;
 	try {
@@ -57,6 +81,56 @@ export async function run(): Promise<void> {
 		packagedCachingFetcher.prototype.startInitialCuratedFetch = originalStartInitialCuratedFetch;
 	}
 	assert.strictEqual(extension.isActive, true);
+	if (expectScannerlessWindows) {
+		try {
+			assert.strictEqual(
+				scanConsentRequests,
+				0,
+				'the scannerless Windows package must not start the local scan consent flow',
+			);
+			await completionConfiguration.update(
+				'scanUnknownCommands',
+				true,
+				vscode.ConfigurationTarget.Global,
+			);
+			await completionConfiguration.update(
+				'enableCompletion',
+				true,
+				vscode.ConfigurationTarget.Global,
+			);
+			const unknownDocument = await vscode.workspace.openTextDocument({
+				language: 'shellscript',
+				content: 'vscode-h2o-scannerless-probe --v',
+			});
+			const unknownCaret = unknownDocument.positionAt(unknownDocument.getText().length);
+			await withTimeout(
+				vscode.commands.executeCommand<vscode.CompletionList>(
+					'vscode.executeCompletionItemProvider',
+					unknownDocument.uri,
+					unknownCaret,
+				),
+				10000,
+			);
+			assert.strictEqual(
+				localScanCalls,
+				0,
+				'the Windows Extension Host must ignore an enabled local scan setting',
+			);
+		} finally {
+			packagedH2oRunnerModule.runH2o = originalRunH2o;
+			packagedScanConsentModule.requestUnknownCommandScanConsent = originalRequestUnknownCommandScanConsent;
+			await completionConfiguration.update(
+				'scanUnknownCommands',
+				undefined,
+				vscode.ConfigurationTarget.Global,
+			);
+			await completionConfiguration.update(
+				'enableCompletion',
+				false,
+				vscode.ConfigurationTarget.Global,
+			);
+		}
+	}
 	const settings = extension.packageJSON.contributes.configuration.properties as Record<
 		string,
 		Record<string, unknown>
@@ -160,6 +234,29 @@ export async function run(): Promise<void> {
 			'the installed VSIX must parse a shell document and provide an option completion',
 		);
 		assert.strictEqual(fetchCalls, 1);
+
+		const hoverSource = 'git --vscode-h2o-packaged-smoke';
+		const hoverDocument = await vscode.workspace.openTextDocument({
+			language: 'shellscript',
+			content: hoverSource,
+		});
+		const hoverPosition = new vscode.Position(0, hoverSource.indexOf('packaged'));
+		const hovers = await withTimeout(
+			vscode.commands.executeCommand<vscode.Hover[]>(
+				'vscode.executeHoverProvider',
+				hoverDocument.uri,
+				hoverPosition,
+			),
+			10000,
+		);
+		const hoverText = hovers
+			.flatMap(hover => hover.contents)
+			.map(content => typeof content === 'string' ? content : content.value)
+			.join('\n');
+		assert.ok(
+			hoverText.includes('packaged parser smoke option'),
+			'the installed VSIX must provide hover from cached command data',
+		);
 
 		const debugReport = await withTimeout(
 			vscode.commands.executeCommand<CaretDebugReport>('h2o.inspectCaretContext'),

--- a/src/test/packaged/index.ts
+++ b/src/test/packaged/index.ts
@@ -57,7 +57,7 @@ export async function run(): Promise<void> {
 	await updateGlobalConfiguration(
 		completionConfiguration,
 		'enableCompletion',
-		false,
+		expectScannerlessWindows ? undefined : false,
 	);
 	await updateGlobalConfiguration(
 		completionConfiguration,
@@ -113,11 +113,6 @@ export async function run(): Promise<void> {
 				'scanUnknownCommands',
 				true,
 			);
-			await updateGlobalConfiguration(
-				completionConfiguration,
-				'enableCompletion',
-				true,
-			);
 			const unknownDocument = await vscode.workspace.openTextDocument({
 				language: 'shellscript',
 				content: 'vscode-h2o-scannerless-probe --v',
@@ -143,11 +138,6 @@ export async function run(): Promise<void> {
 				completionConfiguration,
 				'scanUnknownCommands',
 				undefined,
-			);
-			await updateGlobalConfiguration(
-				completionConfiguration,
-				'enableCompletion',
-				false,
 			);
 		}
 	}
@@ -216,28 +206,30 @@ export async function run(): Promise<void> {
 		const editor = await vscode.window.showTextDocument(document, { preview: false });
 		const caret = document.positionAt(document.getText().length);
 		editor.selection = new vscode.Selection(caret, caret);
-		const disabledCompletion = await withTimeout(
-			vscode.commands.executeCommand<vscode.CompletionList>(
-				'vscode.executeCompletionItemProvider',
-				document.uri,
-				caret,
-			),
-			10000,
-		);
-		assert.ok(
-			!disabledCompletion.items.some(item =>
-				(typeof item.label === 'string' ? item.label : item.label.label)
-				=== '--vscode-h2o-packaged-smoke'
-			),
-			'the installed VSIX must not provide completion while disabled at activation',
-		);
-		assert.strictEqual(fetchCalls, 0);
+		if (!expectScannerlessWindows) {
+			const disabledCompletion = await withTimeout(
+				vscode.commands.executeCommand<vscode.CompletionList>(
+					'vscode.executeCompletionItemProvider',
+					document.uri,
+					caret,
+				),
+				10000,
+			);
+			assert.ok(
+				!disabledCompletion.items.some(item =>
+					(typeof item.label === 'string' ? item.label : item.label.label)
+					=== '--vscode-h2o-packaged-smoke'
+				),
+				'the installed VSIX must not provide completion while disabled at activation',
+			);
+			assert.strictEqual(fetchCalls, 0);
 
-		await updateGlobalConfiguration(
-			completionConfiguration,
-			'enableCompletion',
-			true,
-		);
+			await updateGlobalConfiguration(
+				completionConfiguration,
+				'enableCompletion',
+				true,
+			);
+		}
 		const completion = await withTimeout(
 			vscode.commands.executeCommand<vscode.CompletionList>(
 				'vscode.executeCompletionItemProvider',

--- a/src/test/packaged/index.ts
+++ b/src/test/packaged/index.ts
@@ -46,6 +46,20 @@ async function updateGlobalConfiguration<T>(
 	await withTimeout(changed, 10000);
 }
 
+function loadActivatedExtensionModule<T>(extensionPath: string, relativePath: string): T {
+	const expectedPath = path.resolve(extensionPath, relativePath);
+	const normalizedExpectedPath = process.platform === 'win32'
+		? expectedPath.toLowerCase()
+		: expectedPath;
+	const cachePath = Object.keys(require.cache).find(candidate => {
+		const resolvedCandidate = path.resolve(candidate);
+		return (process.platform === 'win32' ? resolvedCandidate.toLowerCase() : resolvedCandidate)
+			=== normalizedExpectedPath;
+	});
+	assert.ok(cachePath, `${relativePath} must be loaded by the installed extension`);
+	return require(cachePath) as T;
+}
+
 export async function run(): Promise<void> {
 	const expectScannerlessWindows = process.env.VSCODE_H2O_EXPECT_SCANNERLESS_WINDOWS === '1';
 	if (expectScannerlessWindows) {
@@ -71,43 +85,24 @@ export async function run(): Promise<void> {
 	assert.ok(extensionPath.startsWith(`${extensionsDir}${path.sep}`), `${extensionPath} must be inside the isolated extensions directory`);
 	assert.ok(extensionPath !== sourceRoot && !extensionPath.startsWith(`${sourceRoot}${path.sep}`), 'the source checkout must not satisfy the VSIX smoke test');
 
-	const packagedCacheFetcherModule = require(path.join(extensionPath, 'out/cacheFetcher.js')) as typeof import('../../cacheFetcher');
-	const packagedCachingFetcher = packagedCacheFetcherModule.CachingFetcher;
-	const packagedH2oRunnerModule = require(path.join(extensionPath, 'out/h2oRunner.js')) as {
-		runH2o: typeof import('../../h2oRunner').runH2o;
-	};
-	const originalRunH2o = packagedH2oRunnerModule.runH2o;
-	const packagedScanConsentModule = require(path.join(extensionPath, 'out/scanConsent.js')) as {
-		requestUnknownCommandScanConsent: typeof import('../../scanConsent').requestUnknownCommandScanConsent;
-	};
-	const originalRequestUnknownCommandScanConsent = packagedScanConsentModule.requestUnknownCommandScanConsent;
-	let scanConsentRequests = 0;
-	let localScanCalls = 0;
-	if (expectScannerlessWindows) {
-		packagedH2oRunnerModule.runH2o = async () => {
-			localScanCalls += 1;
-			return undefined;
-		};
-		packagedScanConsentModule.requestUnknownCommandScanConsent = async () => {
-			scanConsentRequests += 1;
-			return 'already-prompted';
-		};
-	}
-	const originalStartInitialCuratedFetch = packagedCachingFetcher.prototype.startInitialCuratedFetch;
-	packagedCachingFetcher.prototype.startInitialCuratedFetch = async () => undefined;
-	try {
-		await withTimeout(extension.activate(), 10000);
-	} finally {
-		packagedCachingFetcher.prototype.startInitialCuratedFetch = originalStartInitialCuratedFetch;
-	}
+	await withTimeout(extension.activate(), 10000);
 	assert.strictEqual(extension.isActive, true);
+	const packagedCacheFetcherModule = loadActivatedExtensionModule<typeof import('../../cacheFetcher')>(
+		extensionPath,
+		'out/cacheFetcher.js',
+	);
+	const packagedCachingFetcher = packagedCacheFetcherModule.CachingFetcher;
 	if (expectScannerlessWindows) {
+		const packagedH2oRunnerModule = loadActivatedExtensionModule<{
+			runH2o: typeof import('../../h2oRunner').runH2o;
+		}>(extensionPath, 'out/h2oRunner.js');
+		const originalRunH2o = packagedH2oRunnerModule.runH2o;
+		let localScanCalls = 0;
 		try {
-			assert.strictEqual(
-				scanConsentRequests,
-				0,
-				'the scannerless Windows package must not start the local scan consent flow',
-			);
+			packagedH2oRunnerModule.runH2o = async () => {
+				localScanCalls += 1;
+				return undefined;
+			};
 			await updateGlobalConfiguration(
 				completionConfiguration,
 				'scanUnknownCommands',
@@ -133,7 +128,6 @@ export async function run(): Promise<void> {
 			);
 		} finally {
 			packagedH2oRunnerModule.runH2o = originalRunH2o;
-			packagedScanConsentModule.requestUnknownCommandScanConsent = originalRequestUnknownCommandScanConsent;
 			await updateGlobalConfiguration(
 				completionConfiguration,
 				'scanUnknownCommands',

--- a/src/test/packaged/index.ts
+++ b/src/test/packaged/index.ts
@@ -26,6 +26,26 @@ async function withTimeout<T>(operation: PromiseLike<T>, timeoutMs: number): Pro
 	}
 }
 
+async function updateGlobalConfiguration<T>(
+	configuration: vscode.WorkspaceConfiguration,
+	key: string,
+	value: T | undefined,
+): Promise<void> {
+	if (Object.is(configuration.inspect<T>(key)?.globalValue, value)) {
+		return;
+	}
+	const changed = new Promise<void>(resolve => {
+		const registration = vscode.workspace.onDidChangeConfiguration(event => {
+			if (event.affectsConfiguration(`shellCompletion.${key}`)) {
+				registration.dispose();
+				resolve();
+			}
+		});
+	});
+	await configuration.update(key, value, vscode.ConfigurationTarget.Global);
+	await withTimeout(changed, 10000);
+}
+
 export async function run(): Promise<void> {
 	const expectScannerlessWindows = process.env.VSCODE_H2O_EXPECT_SCANNERLESS_WINDOWS === '1';
 	if (expectScannerlessWindows) {
@@ -34,15 +54,15 @@ export async function run(): Promise<void> {
 	const extension = vscode.extensions.getExtension(extensionId);
 	assert.ok(extension, `${extensionId} must be installed from the VSIX`);
 	const completionConfiguration = vscode.workspace.getConfiguration('shellCompletion');
-	await completionConfiguration.update(
+	await updateGlobalConfiguration(
+		completionConfiguration,
 		'enableCompletion',
 		false,
-		vscode.ConfigurationTarget.Global,
 	);
-	await completionConfiguration.update(
+	await updateGlobalConfiguration(
+		completionConfiguration,
 		'scanUnknownCommands',
 		expectScannerlessWindows ? undefined : false,
-		vscode.ConfigurationTarget.Global,
 	);
 
 	const sourceRoot = path.resolve(process.env.VSCODE_H2O_SOURCE_ROOT!);
@@ -88,15 +108,15 @@ export async function run(): Promise<void> {
 				0,
 				'the scannerless Windows package must not start the local scan consent flow',
 			);
-			await completionConfiguration.update(
+			await updateGlobalConfiguration(
+				completionConfiguration,
 				'scanUnknownCommands',
 				true,
-				vscode.ConfigurationTarget.Global,
 			);
-			await completionConfiguration.update(
+			await updateGlobalConfiguration(
+				completionConfiguration,
 				'enableCompletion',
 				true,
-				vscode.ConfigurationTarget.Global,
 			);
 			const unknownDocument = await vscode.workspace.openTextDocument({
 				language: 'shellscript',
@@ -119,15 +139,15 @@ export async function run(): Promise<void> {
 		} finally {
 			packagedH2oRunnerModule.runH2o = originalRunH2o;
 			packagedScanConsentModule.requestUnknownCommandScanConsent = originalRequestUnknownCommandScanConsent;
-			await completionConfiguration.update(
+			await updateGlobalConfiguration(
+				completionConfiguration,
 				'scanUnknownCommands',
 				undefined,
-				vscode.ConfigurationTarget.Global,
 			);
-			await completionConfiguration.update(
+			await updateGlobalConfiguration(
+				completionConfiguration,
 				'enableCompletion',
 				false,
-				vscode.ConfigurationTarget.Global,
 			);
 		}
 	}
@@ -213,10 +233,10 @@ export async function run(): Promise<void> {
 		);
 		assert.strictEqual(fetchCalls, 0);
 
-		await completionConfiguration.update(
+		await updateGlobalConfiguration(
+			completionConfiguration,
 			'enableCompletion',
 			true,
-			vscode.ConfigurationTarget.Global,
 		);
 		const completion = await withTimeout(
 			vscode.commands.executeCommand<vscode.CompletionList>(

--- a/src/test/runVsixTest.ts
+++ b/src/test/runVsixTest.ts
@@ -37,6 +37,7 @@ async function main(): Promise<void> {
 		execFileSync(cliPath, [...profileArguments, '--install-extension', vsixPath, '--force'], {
 			encoding: 'utf8',
 			env: cliEnvironment,
+			shell: process.platform === 'win32',
 			stdio: 'inherit',
 		});
 

--- a/src/test/unit/cacheFetcher.test.ts
+++ b/src/test/unit/cacheFetcher.test.ts
@@ -1211,7 +1211,6 @@ suite('runH2o', () => {
       extensionDir: '/extension/out',
       platform: 'linux',
       getConfiguredPath: () => '<bundled>',
-      showErrorMessage: () => undefined,
       execute,
     };
   }

--- a/src/test/unit/h2oRunner.test.ts
+++ b/src/test/unit/h2oRunner.test.ts
@@ -5,8 +5,11 @@ import { PassThrough } from 'stream';
 
 import {
   executeProcess,
-  ProcessExecutionDependencies,
+  type H2oRuntime,
+  type ProcessExecutionDependencies,
   ProcessExecutionError,
+  runH2o,
+  supportsLocalCommandScanning,
 } from '../../h2oRunner';
 
 class FakeChildProcess extends EventEmitter {
@@ -181,5 +184,29 @@ suite('asynchronous process execution', () => {
       fake.dependencies,
     ), hasFailureKind('aborted'));
     assert.strictEqual(fake.spawnOptions(), undefined);
+  });
+});
+
+suite('local command scanning support', () => {
+  test('supports only Unix hosts with bundled scanner packages', () => {
+    assert.strictEqual(supportsLocalCommandScanning('linux'), true);
+    assert.strictEqual(supportsLocalCommandScanning('darwin'), true);
+    assert.strictEqual(supportsLocalCommandScanning('win32'), false);
+  });
+
+  test('does not run a configured H2O executable on Windows', async () => {
+    let executions = 0;
+    const runtime: H2oRuntime = {
+      extensionDir: '/extension/out',
+      platform: 'win32',
+      getConfiguredPath: () => 'C:\\tools\\h2o.exe',
+      execute: async () => {
+        executions += 1;
+        return { stdout: '', stderr: '' };
+      },
+    };
+
+    assert.strictEqual(await runH2o('dir', runtime), undefined);
+    assert.strictEqual(executions, 0);
   });
 });


### PR DESCRIPTION
Publishes Windows x64 and arm64 VSIX packages without H2O or local command scanning. Windows keeps downloaded and cached completion and hover data, skips scan consent, and ignores enabled scan settings.

Also adds scannerless VSIX contracts and a Windows Extension Host smoke gate covering activation, consent suppression, scan suppression, completion, and hover.

Local verification:
- npm run check:unit
- Linux, win32-x64, and win32-arm64 package contracts
- packaged Linux Extension Host smoke