### PR TITLE
fix(release): poll Marketplace propagation

### DIFF
--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -27,12 +27,16 @@ publish job to Microsoft Entra ID authentication before that date.
 The publish workflow verifies that the manifest and lockfile versions agree and increased from the previous `main`
 commit. It then re-runs the complete quality workflow, downloads its seven verified platform-specific VSIX artifacts,
 verifies them again, and waits for approval on the `marketplace` environment. After approval it verifies Marketplace
-publishing rights, creates the immutable unprefixed version tag at the merged commit, publishes all targets together,
-and confirms the new Marketplace version.
+publishing rights, creates the immutable unprefixed version tag at the merged commit, and publishes all targets
+together. A separate job outside the protected environment polls the public Marketplace for up to ten minutes until
+the new version is visible for every expected target.
 
 If publication partially succeeds because of a transient failure, re-run only the failed `publish` job. Publishing
 skips packages already present at that version and continues with the missing targets, so this recovery uses the
 original immutable tag and artifacts. Never move, delete, or recreate a version tag. If the artifacts have expired or
 their contents need to change, release a new version instead.
+
+If publication succeeds but Marketplace propagation outlasts the confirmation job, re-run only the failed `confirm`
+job. Confirmation uses no Marketplace credential or protected environment, so this retry requires no release approval.
 
 Do not publish the same extension version manually or from another workflow; duplicate recovery assumes that every existing target came from the original run's verified artifacts.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,9 +113,33 @@ jobs:
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
 
+  confirm:
+    name: Confirm Marketplace release
+    needs:
+      - release-metadata
+      - publish
+    if: needs.release-metadata.outputs.release == 'true' && needs.publish.result == 'success'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - name: Check out approved release tooling
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.release-metadata.outputs.commit }}
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install locked release tooling
+        run: npm ci
+
       - name: Confirm the Marketplace version
         env:
           RELEASE_VERSION: ${{ needs.release-metadata.outputs.version }}
-        run: |
-          published_version="$(npx --no-install vsce show tetradresearch.vscode-h2o --json | jq -r '.versions[0].version')"
-          test "${published_version}" = "${RELEASE_VERSION}"
+        run: node scripts/confirm-marketplace-version.mjs "${RELEASE_VERSION}"

--- a/scripts/confirm-marketplace-version.mjs
+++ b/scripts/confirm-marketplace-version.mjs
@@ -1,0 +1,54 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { setTimeout as delay } from 'node:timers/promises';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import { loadH2oLock } from './lib/h2o-release.mjs';
+import { waitForMarketplaceTargets } from './lib/marketplace-release.mjs';
+
+const projectRoot = fileURLToPath(new URL('..', import.meta.url));
+const [version] = process.argv.slice(2);
+assert.ok(version, 'Usage: node scripts/confirm-marketplace-version.mjs <version>');
+
+const manifest = JSON.parse(readFileSync(path.join(projectRoot, 'package.json'), 'utf8'));
+assert.strictEqual(version, manifest.version, 'Marketplace version differs from package.json');
+const extensionId = `${manifest.publisher}.${manifest.name}`;
+const lock = loadH2oLock(path.join(projectRoot, 'h2o.lock.json'));
+const expectedTargets = Object.keys(lock.vsixTargets).sort();
+
+function inspectMarketplace() {
+  const output = execFileSync(
+    'npx',
+    ['--no-install', 'vsce', 'show', extensionId, '--json'],
+    {
+      cwd: projectRoot,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: 30_000,
+      maxBuffer: 10 * 1024 * 1024,
+    },
+  );
+  return JSON.parse(output);
+}
+
+const result = await waitForMarketplaceTargets({
+  inspect: inspectMarketplace,
+  version,
+  expectedTargets,
+  timeoutMs: 10 * 60 * 1000,
+  intervalMs: 10 * 1000,
+  delay,
+  onAttempt: ({ attempts, missingTargets, error }) => {
+    if (error) {
+      const description = error instanceof Error ? error.message : String(error);
+      console.warn(`Marketplace query ${attempts} failed: ${description}`);
+    } else if (missingTargets.length > 0) {
+      console.log(`Marketplace query ${attempts}: waiting for ${missingTargets.join(', ')}.`);
+    }
+  },
+});
+
+console.log(
+  `Confirmed ${extensionId} ${version} for ${expectedTargets.length} targets after ${result.attempts} query(s).`,
+);

--- a/scripts/lib/marketplace-release.mjs
+++ b/scripts/lib/marketplace-release.mjs
@@ -1,5 +1,7 @@
 import assert from 'node:assert/strict';
 
+const versionPattern = /^[0-9]+\.[0-9]+\.[0-9]+$/;
+
 export function marketplacePublishArguments(packagePaths) {
   assert.ok(packagePaths.length > 0, 'at least one VSIX package is required');
   return [
@@ -10,4 +12,71 @@ export function marketplacePublishArguments(packagePaths) {
     '--packagePath',
     ...packagePaths,
   ];
+}
+
+export function missingMarketplaceTargets(showResult, version, expectedTargets) {
+  assert.match(version, versionPattern, 'Marketplace version must be an unprefixed semantic version');
+  assert.ok(Array.isArray(expectedTargets) && expectedTargets.length > 0, 'at least one Marketplace target is required');
+  assert.strictEqual(
+    new Set(expectedTargets).size,
+    expectedTargets.length,
+    'Marketplace targets must be unique',
+  );
+  assert.ok(Array.isArray(showResult?.versions), 'Marketplace response must contain versions');
+
+  const publishedTargets = new Set(
+    showResult.versions
+      .filter(entry => entry?.version === version && typeof entry.targetPlatform === 'string')
+      .map(entry => entry.targetPlatform),
+  );
+  return expectedTargets.filter(target => !publishedTargets.has(target));
+}
+
+export async function waitForMarketplaceTargets({
+  inspect,
+  version,
+  expectedTargets,
+  timeoutMs,
+  intervalMs,
+  now = Date.now,
+  delay,
+  onAttempt = () => {},
+}) {
+  assert.strictEqual(typeof inspect, 'function', 'Marketplace inspector is required');
+  assert.strictEqual(typeof delay, 'function', 'Marketplace polling delay is required');
+  assert.ok(Number.isSafeInteger(timeoutMs) && timeoutMs > 0, 'Marketplace timeout must be positive');
+  assert.ok(Number.isSafeInteger(intervalMs) && intervalMs > 0, 'Marketplace interval must be positive');
+
+  const startedAt = now();
+  const deadline = startedAt + timeoutMs;
+  let attempts = 0;
+  let missingTargets = [...expectedTargets];
+  let lastError;
+
+  while (now() < deadline) {
+    attempts += 1;
+    try {
+      const showResult = await inspect();
+      missingTargets = missingMarketplaceTargets(showResult, version, expectedTargets);
+      lastError = undefined;
+      onAttempt({ attempts, elapsedMs: now() - startedAt, missingTargets, error: undefined });
+      if (missingTargets.length === 0) {
+        return { attempts, elapsedMs: now() - startedAt };
+      }
+    } catch (error) {
+      lastError = error;
+      onAttempt({ attempts, elapsedMs: now() - startedAt, missingTargets, error });
+    }
+
+    const remainingMs = deadline - now();
+    if (remainingMs <= 0) {
+      break;
+    }
+    await delay(Math.min(intervalMs, remainingMs));
+  }
+
+  const lastErrorSuffix = lastError instanceof Error ? ` Last query failed: ${lastError.message}` : '';
+  throw new Error(
+    `Marketplace did not expose ${version} for ${missingTargets.join(', ')} within ${timeoutMs} ms.${lastErrorSuffix}`,
+  );
 }

--- a/scripts/test-marketplace-release.mjs
+++ b/scripts/test-marketplace-release.mjs
@@ -1,5 +1,9 @@
 import assert from 'node:assert/strict';
-import { marketplacePublishArguments } from './lib/marketplace-release.mjs';
+import {
+  marketplacePublishArguments,
+  missingMarketplaceTargets,
+  waitForMarketplaceTargets,
+} from './lib/marketplace-release.mjs';
 
 const packages = [
   '/release/vscode-h2o-alpine-x64.vsix',
@@ -18,5 +22,99 @@ assert.deepStrictEqual(
   ],
 );
 assert.throws(() => marketplacePublishArguments([]), /at least one VSIX package/);
+
+const expectedTargets = ['alpine-x64', 'linux-x64'];
+const marketplaceResult = (...versions) => ({
+  versions: versions.map(([version, targetPlatform]) => ({ version, targetPlatform })),
+});
+
+assert.deepStrictEqual(
+  missingMarketplaceTargets(
+    marketplaceResult(
+      ['0.3.1', 'alpine-x64'],
+      ['0.3.0', 'linux-x64'],
+      ['0.3.1', 'unrelated-target'],
+    ),
+    '0.3.1',
+    expectedTargets,
+  ),
+  ['linux-x64'],
+);
+assert.deepStrictEqual(
+  missingMarketplaceTargets(
+    marketplaceResult(['0.3.1', 'linux-x64'], ['0.3.1', 'alpine-x64']),
+    '0.3.1',
+    expectedTargets,
+  ),
+  [],
+);
+assert.throws(
+  () => missingMarketplaceTargets({}, '0.3.1', expectedTargets),
+  /must contain versions/,
+);
+assert.throws(
+  () => missingMarketplaceTargets(marketplaceResult(), '0.3.1', ['linux-x64', 'linux-x64']),
+  /must be unique/,
+);
+
+let currentTime = 0;
+const delays = [];
+let inspections = 0;
+const pollResult = await waitForMarketplaceTargets({
+  inspect: () => {
+    inspections += 1;
+    return inspections === 1
+      ? marketplaceResult(['0.3.1', 'alpine-x64'])
+      : marketplaceResult(['0.3.1', 'alpine-x64'], ['0.3.1', 'linux-x64']);
+  },
+  version: '0.3.1',
+  expectedTargets,
+  timeoutMs: 30,
+  intervalMs: 10,
+  now: () => currentTime,
+  delay: async milliseconds => {
+    delays.push(milliseconds);
+    currentTime += milliseconds;
+  },
+});
+assert.deepStrictEqual(pollResult, { attempts: 2, elapsedMs: 10 });
+assert.deepStrictEqual(delays, [10]);
+
+currentTime = 0;
+inspections = 0;
+const transientResult = await waitForMarketplaceTargets({
+  inspect: () => {
+    inspections += 1;
+    if (inspections === 1) {
+      throw new Error('controlled Marketplace outage');
+    }
+    return marketplaceResult(['0.3.1', 'alpine-x64'], ['0.3.1', 'linux-x64']);
+  },
+  version: '0.3.1',
+  expectedTargets,
+  timeoutMs: 30,
+  intervalMs: 10,
+  now: () => currentTime,
+  delay: async milliseconds => {
+    currentTime += milliseconds;
+  },
+});
+assert.deepStrictEqual(transientResult, { attempts: 2, elapsedMs: 10 });
+
+currentTime = 0;
+await assert.rejects(
+  waitForMarketplaceTargets({
+    inspect: () => marketplaceResult(['0.3.1', 'alpine-x64']),
+    version: '0.3.1',
+    expectedTargets,
+    timeoutMs: 20,
+    intervalMs: 10,
+    now: () => currentTime,
+    delay: async milliseconds => {
+      currentTime += milliseconds;
+    },
+  }),
+  /did not expose 0\.3\.1 for linux-x64 within 20 ms/,
+);
 
 console.log('Marketplace release checks passed.');


### PR DESCRIPTION
## Summary
- move Marketplace confirmation out of the protected publish environment
- poll for up to ten minutes until every expected platform target is visible
- tolerate transient Marketplace query failures and document approval-free confirmation retries

## Verification
- npm run check:unit
- node scripts/confirm-marketplace-version.mjs 0.3.1
- parsed .github/workflows/release.yml with yq and Ruby YAML