### PR TITLE
fix(release): verify published VSIX hashes

### DIFF
--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -28,8 +28,8 @@ The publish workflow verifies that the manifest and lockfile versions agree and 
 commit. It then re-runs the complete quality workflow, downloads its seven verified platform-specific VSIX artifacts,
 verifies them again, and waits for approval on the `marketplace` environment. After approval it verifies Marketplace
 publishing rights, creates the immutable unprefixed version tag at the merged commit, and publishes all targets
-together. A separate job outside the protected environment polls the public Marketplace for up to ten minutes until
-the new version is visible for every expected target.
+together. A separate job outside the protected environment downloads and re-verifies the same artifacts, then polls
+the public Marketplace for up to ten minutes until every target is visible with the exact expected VSIX SHA-256.
 
 If publication partially succeeds because of a transient failure, re-run only the failed `publish` job. Publishing
 skips packages already present at that version and continues with the missing targets, so this recovery uses the

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,6 +122,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     permissions:
+      actions: read
       contents: read
     steps:
       - name: Check out approved release tooling
@@ -138,6 +139,16 @@ jobs:
 
       - name: Install locked release tooling
         run: npm ci
+
+      - name: Download verified platform packages
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: vscode-h2o-*-${{ needs.release-metadata.outputs.commit }}
+          path: artifacts
+          merge-multiple: true
+
+      - name: Re-verify downloaded release packages
+        run: npm run verify:release-artifacts
 
       - name: Confirm the Marketplace version
         env:

--- a/scripts/confirm-marketplace-version.mjs
+++ b/scripts/confirm-marketplace-version.mjs
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
-import { readFileSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import { lstatSync, readFileSync } from 'node:fs';
 import { setTimeout as delay } from 'node:timers/promises';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
@@ -8,16 +9,30 @@ import { loadH2oLock } from './lib/h2o-release.mjs';
 import { waitForMarketplaceTargets } from './lib/marketplace-release.mjs';
 
 const projectRoot = fileURLToPath(new URL('..', import.meta.url));
-const [version] = process.argv.slice(2);
-assert.ok(version, 'Usage: node scripts/confirm-marketplace-version.mjs <version>');
+const args = process.argv.slice(2);
+assert.ok(
+  args.length === 1 || args.length === 2,
+  'Usage: node scripts/confirm-marketplace-version.mjs <version> [artifacts-directory]',
+);
+const [version, artifactsArgument] = args;
+const artifactsDirectory = artifactsArgument
+  ? path.resolve(process.cwd(), artifactsArgument)
+  : path.join(projectRoot, 'artifacts');
 
 const manifest = JSON.parse(readFileSync(path.join(projectRoot, 'package.json'), 'utf8'));
 assert.strictEqual(version, manifest.version, 'Marketplace version differs from package.json');
 const extensionId = `${manifest.publisher}.${manifest.name}`;
 const lock = loadH2oLock(path.join(projectRoot, 'h2o.lock.json'));
-const expectedTargets = Object.keys(lock.vsixTargets).sort();
+const expectedPackages = Object.keys(lock.vsixTargets).sort().map(target => {
+  const packagePath = path.join(artifactsDirectory, `vscode-h2o-${target}.vsix`);
+  assert.ok(lstatSync(packagePath).isFile(), `Marketplace package is not a regular file: ${packagePath}`);
+  return {
+    target,
+    sha256: createHash('sha256').update(readFileSync(packagePath)).digest('hex'),
+  };
+});
 
-function inspectMarketplace() {
+function inspectMarketplace({ timeoutMs }) {
   const output = execFileSync(
     'npx',
     ['--no-install', 'vsce', 'show', extensionId, '--json'],
@@ -25,7 +40,7 @@ function inspectMarketplace() {
       cwd: projectRoot,
       encoding: 'utf8',
       stdio: ['ignore', 'pipe', 'pipe'],
-      timeout: 30_000,
+      timeout: Math.min(30_000, timeoutMs),
       maxBuffer: 10 * 1024 * 1024,
     },
   );
@@ -35,20 +50,23 @@ function inspectMarketplace() {
 const result = await waitForMarketplaceTargets({
   inspect: inspectMarketplace,
   version,
-  expectedTargets,
+  expectedPackages,
   timeoutMs: 10 * 60 * 1000,
   intervalMs: 10 * 1000,
   delay,
-  onAttempt: ({ attempts, missingTargets, error }) => {
+  onAttempt: ({ attempts, mismatches, error }) => {
     if (error) {
       const description = error instanceof Error ? error.message : String(error);
       console.warn(`Marketplace query ${attempts} failed: ${description}`);
-    } else if (missingTargets.length > 0) {
-      console.log(`Marketplace query ${attempts}: waiting for ${missingTargets.join(', ')}.`);
+    } else if (mismatches.length > 0) {
+      const pending = mismatches.map(mismatch => (
+        mismatch.reason === 'missing' ? `${mismatch.target} (missing)` : `${mismatch.target} (SHA-256 mismatch)`
+      ));
+      console.log(`Marketplace query ${attempts}: waiting for ${pending.join(', ')}.`);
     }
   },
 });
 
 console.log(
-  `Confirmed ${extensionId} ${version} for ${expectedTargets.length} targets after ${result.attempts} query(s).`,
+  `Confirmed ${extensionId} ${version} for ${expectedPackages.length} exact packages after ${result.attempts} query(s).`,
 );

--- a/scripts/lib/marketplace-release.mjs
+++ b/scripts/lib/marketplace-release.mjs
@@ -1,6 +1,8 @@
 import assert from 'node:assert/strict';
 
 const versionPattern = /^[0-9]+\.[0-9]+\.[0-9]+$/;
+const sha256Pattern = /^[0-9a-f]{64}$/;
+const vsixSha256Property = 'Microsoft.VisualStudio.Services.VsixSha256';
 
 export function marketplacePublishArguments(packagePaths) {
   assert.ok(packagePaths.length > 0, 'at least one VSIX package is required');
@@ -14,28 +16,74 @@ export function marketplacePublishArguments(packagePaths) {
   ];
 }
 
-export function missingMarketplaceTargets(showResult, version, expectedTargets) {
-  assert.match(version, versionPattern, 'Marketplace version must be an unprefixed semantic version');
-  assert.ok(Array.isArray(expectedTargets) && expectedTargets.length > 0, 'at least one Marketplace target is required');
-  assert.strictEqual(
-    new Set(expectedTargets).size,
-    expectedTargets.length,
-    'Marketplace targets must be unique',
+function validateExpectedPackages(expectedPackages) {
+  assert.ok(
+    Array.isArray(expectedPackages) && expectedPackages.length > 0,
+    'at least one Marketplace package is required',
   );
+  for (const expectedPackage of expectedPackages) {
+    assert.ok(
+      typeof expectedPackage?.target === 'string' && expectedPackage.target.length > 0,
+      'Marketplace package target must be a non-empty string',
+    );
+    assert.match(
+      expectedPackage.sha256,
+      sha256Pattern,
+      `Marketplace package SHA-256 for ${expectedPackage.target} must be lowercase hexadecimal`,
+    );
+  }
+  assert.strictEqual(
+    new Set(expectedPackages.map(expectedPackage => expectedPackage.target)).size,
+    expectedPackages.length,
+    'Marketplace package targets must be unique',
+  );
+}
+
+export function marketplaceTargetMismatches(showResult, version, expectedPackages) {
+  assert.match(version, versionPattern, 'Marketplace version must be an unprefixed semantic version');
+  validateExpectedPackages(expectedPackages);
   assert.ok(Array.isArray(showResult?.versions), 'Marketplace response must contain versions');
 
-  const publishedTargets = new Set(
-    showResult.versions
-      .filter(entry => entry?.version === version && typeof entry.targetPlatform === 'string')
-      .map(entry => entry.targetPlatform),
-  );
-  return expectedTargets.filter(target => !publishedTargets.has(target));
+  return expectedPackages.flatMap(expectedPackage => {
+    const publishedPackages = showResult.versions.filter(
+      entry => entry?.version === version && entry.targetPlatform === expectedPackage.target,
+    );
+    if (publishedPackages.length === 0) {
+      return [{ ...expectedPackage, actualSha256: null, reason: 'missing' }];
+    }
+
+    const publishedHashes = publishedPackages.flatMap(entry => {
+      if (!Array.isArray(entry.properties)) {
+        return [];
+      }
+      return entry.properties
+        .filter(property => property?.key === vsixSha256Property && typeof property.value === 'string')
+        .map(property => property.value);
+    });
+    if (publishedHashes.includes(expectedPackage.sha256)) {
+      return [];
+    }
+    return [{
+      ...expectedPackage,
+      actualSha256: publishedHashes[0] ?? null,
+      reason: 'sha256',
+    }];
+  });
+}
+
+function describeMismatches(mismatches) {
+  return mismatches.map(mismatch => {
+    if (mismatch.reason === 'missing') {
+      return `${mismatch.target} (missing)`;
+    }
+    return `${mismatch.target} (SHA-256 ${mismatch.actualSha256 ?? 'unavailable'}, expected ${mismatch.sha256})`;
+  }).join(', ');
 }
 
 export async function waitForMarketplaceTargets({
   inspect,
   version,
-  expectedTargets,
+  expectedPackages,
   timeoutMs,
   intervalMs,
   now = Date.now,
@@ -46,26 +94,35 @@ export async function waitForMarketplaceTargets({
   assert.strictEqual(typeof delay, 'function', 'Marketplace polling delay is required');
   assert.ok(Number.isSafeInteger(timeoutMs) && timeoutMs > 0, 'Marketplace timeout must be positive');
   assert.ok(Number.isSafeInteger(intervalMs) && intervalMs > 0, 'Marketplace interval must be positive');
+  marketplaceTargetMismatches({ versions: [] }, version, expectedPackages);
 
   const startedAt = now();
   const deadline = startedAt + timeoutMs;
   let attempts = 0;
-  let missingTargets = [...expectedTargets];
+  let mismatches = expectedPackages.map(expectedPackage => ({
+    ...expectedPackage,
+    actualSha256: null,
+    reason: 'missing',
+  }));
   let lastError;
 
   while (now() < deadline) {
+    const queryTimeoutMs = deadline - now();
+    if (queryTimeoutMs <= 0) {
+      break;
+    }
     attempts += 1;
     try {
-      const showResult = await inspect();
-      missingTargets = missingMarketplaceTargets(showResult, version, expectedTargets);
+      const showResult = await inspect({ timeoutMs: queryTimeoutMs });
+      mismatches = marketplaceTargetMismatches(showResult, version, expectedPackages);
       lastError = undefined;
-      onAttempt({ attempts, elapsedMs: now() - startedAt, missingTargets, error: undefined });
-      if (missingTargets.length === 0) {
+      onAttempt({ attempts, elapsedMs: now() - startedAt, mismatches, error: undefined });
+      if (mismatches.length === 0) {
         return { attempts, elapsedMs: now() - startedAt };
       }
     } catch (error) {
       lastError = error;
-      onAttempt({ attempts, elapsedMs: now() - startedAt, missingTargets, error });
+      onAttempt({ attempts, elapsedMs: now() - startedAt, mismatches, error });
     }
 
     const remainingMs = deadline - now();
@@ -77,6 +134,6 @@ export async function waitForMarketplaceTargets({
 
   const lastErrorSuffix = lastError instanceof Error ? ` Last query failed: ${lastError.message}` : '';
   throw new Error(
-    `Marketplace did not expose ${version} for ${missingTargets.join(', ')} within ${timeoutMs} ms.${lastErrorSuffix}`,
+    `Marketplace did not expose ${version} with verified VSIX hashes for ${describeMismatches(mismatches)} within ${timeoutMs} ms.${lastErrorSuffix}`,
   );
 }

--- a/scripts/test-marketplace-release.mjs
+++ b/scripts/test-marketplace-release.mjs
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import {
   marketplacePublishArguments,
-  missingMarketplaceTargets,
+  marketplaceTargetMismatches,
   waitForMarketplaceTargets,
 } from './lib/marketplace-release.mjs';
 
@@ -23,52 +23,93 @@ assert.deepStrictEqual(
 );
 assert.throws(() => marketplacePublishArguments([]), /at least one VSIX package/);
 
-const expectedTargets = ['alpine-x64', 'linux-x64'];
+const alpineHash = 'a'.repeat(64);
+const linuxHash = 'b'.repeat(64);
+const unexpectedHash = 'c'.repeat(64);
+const expectedPackages = [
+  { target: 'alpine-x64', sha256: alpineHash },
+  { target: 'linux-x64', sha256: linuxHash },
+];
 const marketplaceResult = (...versions) => ({
-  versions: versions.map(([version, targetPlatform]) => ({ version, targetPlatform })),
+  versions: versions.map(([version, targetPlatform, sha256]) => ({
+    version,
+    targetPlatform,
+    properties: sha256 === undefined ? [] : [{
+      key: 'Microsoft.VisualStudio.Services.VsixSha256',
+      value: sha256,
+    }],
+  })),
 });
 
 assert.deepStrictEqual(
-  missingMarketplaceTargets(
+  marketplaceTargetMismatches(
     marketplaceResult(
-      ['0.3.1', 'alpine-x64'],
-      ['0.3.0', 'linux-x64'],
-      ['0.3.1', 'unrelated-target'],
+      ['0.3.1', 'alpine-x64', alpineHash],
+      ['0.3.0', 'linux-x64', linuxHash],
+      ['0.3.1', 'unrelated-target', unexpectedHash],
     ),
     '0.3.1',
-    expectedTargets,
+    expectedPackages,
   ),
-  ['linux-x64'],
+  [{ target: 'linux-x64', sha256: linuxHash, actualSha256: null, reason: 'missing' }],
 );
 assert.deepStrictEqual(
-  missingMarketplaceTargets(
-    marketplaceResult(['0.3.1', 'linux-x64'], ['0.3.1', 'alpine-x64']),
+  marketplaceTargetMismatches(
+    marketplaceResult(
+      ['0.3.1', 'linux-x64', unexpectedHash],
+      ['0.3.1', 'alpine-x64', alpineHash],
+    ),
     '0.3.1',
-    expectedTargets,
+    expectedPackages,
+  ),
+  [{ target: 'linux-x64', sha256: linuxHash, actualSha256: unexpectedHash, reason: 'sha256' }],
+);
+assert.deepStrictEqual(
+  marketplaceTargetMismatches(
+    marketplaceResult(
+      ['0.3.1', 'linux-x64', linuxHash],
+      ['0.3.1', 'alpine-x64', alpineHash],
+    ),
+    '0.3.1',
+    expectedPackages,
   ),
   [],
 );
 assert.throws(
-  () => missingMarketplaceTargets({}, '0.3.1', expectedTargets),
+  () => marketplaceTargetMismatches({}, '0.3.1', expectedPackages),
   /must contain versions/,
 );
 assert.throws(
-  () => missingMarketplaceTargets(marketplaceResult(), '0.3.1', ['linux-x64', 'linux-x64']),
+  () => marketplaceTargetMismatches(marketplaceResult(), '0.3.1', [
+    { target: 'linux-x64', sha256: linuxHash },
+    { target: 'linux-x64', sha256: linuxHash },
+  ]),
   /must be unique/,
+);
+assert.throws(
+  () => marketplaceTargetMismatches(marketplaceResult(), '0.3.1', [
+    { target: 'linux-x64', sha256: 'not-a-sha256' },
+  ]),
+  /must be lowercase hexadecimal/,
 );
 
 let currentTime = 0;
 const delays = [];
+const queryTimeouts = [];
 let inspections = 0;
 const pollResult = await waitForMarketplaceTargets({
-  inspect: () => {
+  inspect: ({ timeoutMs }) => {
+    queryTimeouts.push(timeoutMs);
     inspections += 1;
     return inspections === 1
-      ? marketplaceResult(['0.3.1', 'alpine-x64'])
-      : marketplaceResult(['0.3.1', 'alpine-x64'], ['0.3.1', 'linux-x64']);
+      ? marketplaceResult(['0.3.1', 'alpine-x64', alpineHash])
+      : marketplaceResult(
+        ['0.3.1', 'alpine-x64', alpineHash],
+        ['0.3.1', 'linux-x64', linuxHash],
+      );
   },
   version: '0.3.1',
-  expectedTargets,
+  expectedPackages,
   timeoutMs: 30,
   intervalMs: 10,
   now: () => currentTime,
@@ -79,6 +120,7 @@ const pollResult = await waitForMarketplaceTargets({
 });
 assert.deepStrictEqual(pollResult, { attempts: 2, elapsedMs: 10 });
 assert.deepStrictEqual(delays, [10]);
+assert.deepStrictEqual(queryTimeouts, [30, 20]);
 
 currentTime = 0;
 inspections = 0;
@@ -88,10 +130,13 @@ const transientResult = await waitForMarketplaceTargets({
     if (inspections === 1) {
       throw new Error('controlled Marketplace outage');
     }
-    return marketplaceResult(['0.3.1', 'alpine-x64'], ['0.3.1', 'linux-x64']);
+    return marketplaceResult(
+      ['0.3.1', 'alpine-x64', alpineHash],
+      ['0.3.1', 'linux-x64', linuxHash],
+    );
   },
   version: '0.3.1',
-  expectedTargets,
+  expectedPackages,
   timeoutMs: 30,
   intervalMs: 10,
   now: () => currentTime,
@@ -102,11 +147,18 @@ const transientResult = await waitForMarketplaceTargets({
 assert.deepStrictEqual(transientResult, { attempts: 2, elapsedMs: 10 });
 
 currentTime = 0;
+const deadlineQueryTimeouts = [];
 await assert.rejects(
   waitForMarketplaceTargets({
-    inspect: () => marketplaceResult(['0.3.1', 'alpine-x64']),
+    inspect: ({ timeoutMs }) => {
+      deadlineQueryTimeouts.push(timeoutMs);
+      return marketplaceResult(
+        ['0.3.1', 'alpine-x64', alpineHash],
+        ['0.3.1', 'linux-x64', unexpectedHash],
+      );
+    },
     version: '0.3.1',
-    expectedTargets,
+    expectedPackages,
     timeoutMs: 20,
     intervalMs: 10,
     now: () => currentTime,
@@ -114,7 +166,8 @@ await assert.rejects(
       currentTime += milliseconds;
     },
   }),
-  /did not expose 0\.3\.1 for linux-x64 within 20 ms/,
+  /did not expose 0\.3\.1 with verified VSIX hashes for linux-x64 \(SHA-256/,
 );
+assert.deepStrictEqual(deadlineQueryTimeouts, [20, 10]);
 
 console.log('Marketplace release checks passed.');


### PR DESCRIPTION
## Summary

- download and re-verify the release artifacts in the unprotected confirmation job
- require each Marketplace target to expose the exact verified VSIX SHA-256
- bound every Marketplace query by the remaining ten-minute polling budget

This follows up on the independent review of #22.

## Verification

- `npm run check:unit`
- `node scripts/test-marketplace-release.mjs`
- live confirmation against all seven v0.3.1 workflow artifacts and Marketplace hashes
- workflow YAML parsed with yq and Ruby YAML